### PR TITLE
feat: main Page Layout

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,4 +1,5 @@
 import { routePaths } from '../constants/path';
+import MainPage from '../pages/MainPage/MainPage';
 import SignIn from '../pages/SignIn/SignIn';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
@@ -7,7 +8,7 @@ const App = () => {
       <BrowserRouter>
         <Routes>
           <Route path={routePaths.login} element={<SignIn />} />
-          <Route path={routePaths.main} element={<div>main</div>} />
+          <Route path={routePaths.home} element={<MainPage />} />
           <Route path={routePaths.myPage} element={<div>myPage</div>} />
           <Route path={routePaths.record} element={<div>record</div>} />
           <Route path={routePaths.admin} element={<div>admin</div>} />

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,0 +1,26 @@
+import Style from "./MainPage.style";
+import logoBook from "../../assets/images/logo/Logo_book.png";
+import { Link } from "react-router-dom";
+import { routePaths } from "../../constants/path";
+
+function MainPage() {
+  return (
+    <Style.LayoutContainer>
+      <Link to={routePaths.home}>
+        <Style.SrOnly>Fullio</Style.SrOnly>
+        <Style.LogoImage src={logoBook} />
+      </Link>
+      <div>네비</div>
+      <Style.ContentsGrid>
+        <div>달력</div>
+        <div>서치바</div>
+        <div>activity</div>
+        <div>my skill</div>
+        <div>info</div>
+        <div>month record</div>
+      </Style.ContentsGrid>
+    </Style.LayoutContainer>
+  );
+}
+
+export default MainPage;

--- a/src/pages/MainPage/MainPage.style.js
+++ b/src/pages/MainPage/MainPage.style.js
@@ -1,0 +1,71 @@
+import { styled } from "styled-components";
+
+const LayoutContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  margin: 88px auto 0;
+  width: fit-content;
+
+  & > a {
+    position: absolute;
+    top: -72px;
+    left: 0;
+  }
+`;
+const SrOnly = styled.h1`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  top: -72px;
+  left: 0;
+`;
+const ContentsGrid = styled.div`
+  display: grid;
+  grid-template-columns: 332px 448px 332px;
+  grid-template-rows: 56px 115px 194px 319px;
+  grid-gap: 16px;
+
+  & div:nth-child(1) {
+    grid-column: 1 / 2;
+    grid-row: 1 / 4;
+  }
+  & div:nth-child(2) {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+  }
+  & div:nth-child(3) {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+  }
+  & div:nth-child(4) {
+    grid-column: 2 / 3;
+    grid-row: 3 / 4;
+  }
+  & div:nth-child(5) {
+    grid-column: 3 / 4;
+    grid-row: 1 / 5;
+  }
+  & div:nth-child(6) {
+    grid-column: 1 / 4;
+    grid-row: 4 / 5;
+  }
+`;
+
+const LogoImage = styled.img`
+  width:37px;
+  height: 56px;
+`;
+
+export default {
+  LayoutContainer,
+  ContentsGrid,
+  LogoImage,
+  SrOnly,
+}


### PR DESCRIPTION
### feat: main Page Layout
 - 메인페이지 레이아웃


### 내용
 - 네비 영역, 컨텐츠 영역 두가지로 나누었음.
 - 컨텐츠 영역은 Grid로 구성하였음.
 - Grid 영역은 하나의 컴포넌트로 자식요소의 배치를 & div:nth-child()로 배치
 - 순서는 Calendar, SearchBar, Activity, MySkill, Info, MonthRecord 순으로 배치